### PR TITLE
Update search_query callback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ set(CMAKE_CXX_COMPILER mpicxx)
 #  -DT8CODE_DIR=PATH,
 #  -DP4EST_DIR=PATH,
 #  -DSC_DIR=PATH,
-find_package ( T8CODE 2.0 REQUIRED)
+find_package ( T8CODE 3.0 REQUIRED)
 
 # Using PNG_INCLUDE and PNG_LIB is only necessary when
 # the compiler does not find the PNG library.

--- a/png2mesh_build_mesh.cxx
+++ b/png2mesh_build_mesh.cxx
@@ -108,7 +108,19 @@ png2mesh_search_callback (t8_forest_t forest,
                           const int is_leaf,
                           const t8_element_array_t *leaf_elements,
                           const t8_locidx_t
-                          tree_leaf_index, void *query, sc_array_t *query_indices,
+                          tree_leaf_index)
+{
+  return 1;
+}
+
+void
+png2mesh_query_callback (t8_forest_t forest,
+                          const t8_locidx_t ltreeid,
+                          const t8_element_t *element,
+                          const int is_leaf,
+                          const t8_element_array_t *leaf_elements,
+                          const t8_locidx_t
+                          tree_leaf_index, sc_array_t *query, sc_array_t *query_indices,
                           int *query_matches, const size_t num_active_queries)
 {
   if (query != NULL) {
@@ -162,7 +174,7 @@ png2mesh_search_callback (t8_forest_t forest,
                                               element_index) = 1;
             /* We can end the search recursion here since we have found one matching pixel and will refine the element. */
             T8_FREE (is_inside);
-            return 1;
+            return;
           }
         }
       }
@@ -170,9 +182,9 @@ png2mesh_search_callback (t8_forest_t forest,
     T8_FREE (is_inside);
   }
   else {                        /* query == NULL */
-    return 1;
+   return;
   }
-  return 0;
+  return;
 }
 
 int
@@ -299,7 +311,7 @@ build_forest (int level, int element_choice, sc_MPI_Comm comm,
     }
     /* Search and create the refinement markers. */
     t8_forest_search (forest, png2mesh_search_callback,
-                      png2mesh_search_callback, &search_queries);
+                      png2mesh_query_callback, &search_queries);
     t8_forest_init (&forest_adapt);
     t8_forest_set_adapt (forest_adapt, forest, png2mesh_adapt, 0);
     t8_forest_set_partition (forest_adapt, forest, 0);


### PR DESCRIPTION
Update png2mesh to match the changed search_query callback from t8code, which was updated in:
 [split search_query callback function into two
](https://github.com/DLR-AMR/t8code/commit/ffc7abf8b6f999d4266a4769f224cbc814307e22#diff-a5e4cb374aab0dead97c359e7ceedc75a81ab11151d2be8d0becd5cae9c84b48R41) and
 [Changed return type of query function to void
](https://github.com/DLR-AMR/t8code/commit/63591f6ce77f1229eeb80465ec34c1da5fd7159e)